### PR TITLE
Same key issue

### DIFF
--- a/jsonxx.cc
+++ b/jsonxx.cc
@@ -307,6 +307,7 @@ bool Object::parse(std::istream& input, Object& object) {
             delete v;
             break;
         }
+        JSONXX_ASSERT(object.value_map_.find(key) != object.value_map_.end());
         object.value_map_[key] = v;
     } while (match(",", input));
 

--- a/jsonxx.cc
+++ b/jsonxx.cc
@@ -307,7 +307,7 @@ bool Object::parse(std::istream& input, Object& object) {
             delete v;
             break;
         }
-        JSONXX_ASSERT(object.value_map_.find(key) != object.value_map_.end());
+        JSONXX_ASSERT(object.value_map_.find(key) == object.value_map_.end());
         object.value_map_[key] = v;
     } while (match(",", input));
 


### PR DESCRIPTION
In case key in map exists (e.g. faulty json file) key becomes overwritten by Value *v which causes huge memory leaks but no errors ;)